### PR TITLE
Proposal: Extend from ActiveModel

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,8 @@
+v2.0.0:
+  date: 2015-01-30
+  changes:
+    - Extend from ActiveModel instead of REST adapter/serializer
+v1.0.1:
+  date: 2015-01-19
+  changes:
+    - Dasherize URL paths.

--- a/addon/adapter.js
+++ b/addon/adapter.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-export default DS.RESTAdapter.extend({
+export default DS.ActiveModelAdapter.extend({
   defaultSerializer: 'endpoints',
+
   buildURL: function(type, id, record) {
     var url = this._super(type, id, record);
     var includes = [];
@@ -19,6 +20,7 @@ export default DS.RESTAdapter.extend({
 
     return url;
   },
+
   // Workaround where REST URLs were getting camelCased
   // https://github.com/ember-cli/ember-cli/issues/2906
   pathForType: function(type) {

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -1,10 +1,10 @@
-import DS from "ember-data";
 import Ember from 'ember';
+import DS from 'ember-data';
 
 var dasherize = Ember.String.dasherize;
 var pluralize = Ember.String.pluralize;
 
-export default DS.RESTSerializer.extend({
+export default DS.ActiveModelSerializer.extend({
 
   normalize: function(type, hash, prop) {
     var links = hash.links;
@@ -29,13 +29,6 @@ export default DS.RESTSerializer.extend({
       delete payload.linked;
     }
     return this._super(payload);
-  },
-
-  keyForRelationship: function(key, relationship) {
-    if (relationship === 'belongsTo') {
-      return key + '_id';
-    }
-    return key;
   },
 
   serializeIntoHash: function(data, type, record, options) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data-endpoints",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
I was running into bugs in the ember-data-endpoints adapter that I
wasn't running into using ActiveModelAdapter (such as date fields
not normalizing, etc.).

I propose we extend from ActiveModel, which, except for pathForType,
and serializing, works with our API.

The empty extend serializer in this commit will be necessary for
adding the serializeIntoHash method to make it nest-api-compat.
